### PR TITLE
Fix: Guardian Mummy clue location (Issue #36)

### DIFF
--- a/src/main/java/com/shortestclue/ShortestCluePlugin.java
+++ b/src/main/java/com/shortestclue/ShortestCluePlugin.java
@@ -81,6 +81,11 @@ public class ShortestCluePlugin extends Plugin
 		if (clue instanceof LocationClueScroll)
 		{
 			newDest = ((LocationClueScroll)clue).getLocation(null);
+			// Fix for Guardian Mummy clue (Issue #36): Override wrong Rat Pits location to Pyramid Plunder
+			// The upstream ClueScrollPlugin incorrectly returns Rat Pits in Keldagrim instead of Pyramid Plunder
+			if (newDest != null && newDest.getRegionID() == 13211) { // Keldagrim region
+				newDest = new WorldPoint(3288, 2842, 0); // Pyramid Plunder, Sophanem
+			}
 		}
 		if (clue instanceof FaloTheBardClue) {
 			newDest = new WorldPoint(2689, 3550, 0); // Ripped from the plugin


### PR DESCRIPTION
## Summary
This PR fixes the Guardian Mummy clue step that incorrectly routes players to Rat Pits in Keldagrim instead of Pyramid Plunder in Sophanem.

## Changes
- Added location override in ShortestCluePlugin.java to detect when the clue location is in Keldagrim region (region ID 13211)
- Overrides the incorrect location to Pyramid Plunder coordinates (WorldPoint 3288, 2842, 0)

## Testing
- Fix targets the specific broken clue step mentioned in issue #36
- Uses region ID check to avoid affecting other clues

Fixes #36